### PR TITLE
Code change to make email comparison case-insensitive.  

### DIFF
--- a/public/js/script.js
+++ b/public/js/script.js
@@ -79,12 +79,14 @@ function InviteInit() {
 
 			$.each(matches, function(i, el){
 				el = el.replace(/ /g, '');
+        el = el.toLowerCase();
 				if($.inArray(el, emails) === -1) emails.push(el);
 			});
 
 			emails.forEach(function (email) {
 				$('.user-email').each(function(){
-					if ($(this).html().trim() === email) {
+					if ($(this).html().trim().toLowerCase() === email.toLowerCase()) {
+            console.log('exists');
 						exists = true;
 					}
 				});


### PR DESCRIPTION
While RFC 5321 indicates the local-part to be case sensitive, in practice most major email providers do not distinguish addresses based on case.  Further, we'd want to keep email duplicates to a minimum